### PR TITLE
ghi-62: fix `onLoad` prop documentation

### DIFF
--- a/packages/docs/content/docs/basic-usage.mdx
+++ b/packages/docs/content/docs/basic-usage.mdx
@@ -60,7 +60,7 @@ The `Root` component is the main container that manages the PDF document state:
   source='/path/to/pdf' // URL or path to PDF file
   className='...' // Container styling
   loader={<Loading />} // Custom loading component
-  onLoad={handleLoad} // Called when PDF is loaded
+  onDocumentLoad={handleLoad} // Called when PDF is loaded
   onError={handleError} // Called on load error
 >
   {/* Child components */}


### PR DESCRIPTION
seems documenation holds an old `onLoad` property which is not fired when doc loaded, by checking the directly props from typescript there is another property called `onDocumentLoad` which is working fine