### PR TITLE
The page component create a div with wrong dimension when the PDF has rotation

### DIFF
--- a/packages/lector/src/components/page.tsx
+++ b/packages/lector/src/components/page.tsx
@@ -15,8 +15,25 @@ export const Page = ({
 }) => {
   const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 
-  const width = (pdfPageProxy.view[2] ?? 0) - (pdfPageProxy.view[0] ?? 0);
-  const height = (pdfPageProxy.view[3] ?? 0) - (pdfPageProxy.view[1] ?? 0);
+  /**
+   * When the PDF has some rotation, creating the div with width/height dimensions
+   * directly from the "view" array attribute can lead to incorrect rectangle,
+   * and so possible wrong layer positioning (i.e., highlighting).
+   * Instead, we have to use the width/height from the page viewport that are
+   * build taking into consideration the possible PDF rotation
+   */
+  const viewports = usePdf((state) => state.viewports);
+  let width:number;
+  let height:number;
+
+  const pageViewport = viewports[pageNumber];
+  if(pageViewport) {
+    width = pageViewport.width;
+    height = pageViewport.height;
+  } else {
+    width = (pdfPageProxy.view[2] ?? 0) - (pdfPageProxy.view[0] ?? 0);
+    height = (pdfPageProxy.view[3] ?? 0) - (pdfPageProxy.view[1] ?? 0);
+  }
 
   return (
     <PDFPageNumberContext.Provider value={pdfPageProxy.pageNumber}>

--- a/packages/lector/src/components/page.tsx
+++ b/packages/lector/src/components/page.tsx
@@ -16,9 +16,10 @@ export const Page = ({
   const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 
   /**
-   * When the PDF has some rotation, creating the div with width/height dimensions
-   * directly from the "view" array attribute can lead to incorrect rectangle,
-   * and so possible wrong layer positioning (i.e., highlighting).
+   * When the PDF has some rotation, creating the div with width/height
+   * dimensions directly from the "view" array attribute can lead
+   * to incorrect rectangle, and so possible wrong layer positioning
+   * (i.e., highlighting).
    * Instead, we have to use the width/height from the page viewport that are
    * build taking into consideration the possible PDF rotation
    */


### PR DESCRIPTION
Dear lector team,

When I'm using lector with a PDF that has rotation (i.e., 270°), the content is display property thanks to your generateViewports function that take into account the PDF rotation. 

But the page component use raw width/height parameter instead of using the width/height from the calculated viewport. This lead to wrong div dimension (ui issue) and possible wrong layer positioning. 

In example when I using your jumpToHighlightRects function, the layer is not placed correctly.

So, this fix aims to take width/height from the page viewport instead of the view array.

Thanks !